### PR TITLE
Add Japanese README translation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,541 @@
+<p align="center"><img src="./data/images/banner.svg" alt="GPT-Image2 Prompt System" width="800" /></p>
+
+<h3 align="center">Prompt as Code | GPT-Image2 産業レベルのプロンプトエンジンとテンプレートライブラリ、400+ 件のリバースエンジニアリング事例、20+ 種の実務向けテンプレート</h3>
+
+<p align="center">
+  <a href="https://github.com/freestylefly/awesome-gpt-image-2"><img src="https://img.shields.io/github/stars/freestylefly/awesome-gpt-image-2?style=flat-square&color=rgb(25%2C%20121%2C%20255)" alt="Stars"></a>
+  <a href="https://github.com/freestylefly/awesome-gpt-image-2"><img src="https://img.shields.io/github/forks/freestylefly/awesome-gpt-image-2?style=flat-square&color=green" alt="Forks"></a>
+  <a href="https://github.com/freestylefly/awesome-gpt-image-2"><img src="https://img.shields.io/badge/Cases-484-blueviolet?style=flat-square" alt="Cases"></a>
+  <a href="https://github.com/freestylefly/awesome-gpt-image-2"><img src="https://img.shields.io/badge/100%25-Original_AI_Rewritten-green?style=flat-square" alt="Original"></a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a> | <a href="./README.zh-CN.md">简体中文</a> | <strong>日本語</strong>
+</p>
+
+> 新しいワークフローや活用例を不定期に更新しています。Star をいただけると励みになります。
+> 本プロジェクトは、GPT Image 2 を高いコストパフォーマンスで利用できる AI 集約プラットフォーム [Ciyuan API](https://ciyuan.today/) の支援を受けています。
+
+## 🌐 ビジュアル Web サイト
+
+[gpt-image2.canghe.ai](https://gpt-image2.canghe.ai/) では、プロダクトとして整備された体験でギャラリーを閲覧できます。大きなプレビューの確認、プロンプト全文のコピー、スタイルやシナリオによる絞り込み、Google ログイン後の生成テスト、GitHub 上の元ケースへの移動ができます。
+
+<p align="center">
+  <a href="https://gpt-image2.canghe.ai/">
+    <img src="data/images/site-preview.png" alt="GPT-Image2 Gallery Web サイトのプレビュー" width="900">
+  </a>
+</p>
+
+## WeChat 公式アカウント
+
+WeChat で **苍何(Canghe)** を検索するか、下の QR カードをスキャンしてください。GPT-Image2 コミュニティグループに参加するには、公式アカウントをフォローしたうえで中国語で **gpt-image-2交流群**(GPT-Image-2 交流グループ)と返信してください。
+
+<p align="center">
+  <img src="data/images/wechat-community.jpg" alt="苍何 WeChat コミュニティ QR カード" width="760">
+</p>
+
+<a name="section-vision"></a>
+
+## ⚡️ プロジェクトビジョン
+
+GPT-Image2 が広く利用できるようになったことで、AI 画像生成の焦点は「画像を生成できるか」から「安定し、制御でき、再利用できる画像を生成できるか」へ移りました。本プロジェクトは、コミュニティに散在する事例を、Agent や自動化ワークフローから再利用しやすい Prompt-as-Code アセットへ整理することを目的としています。
+
+中心となる目標は明快です。散文的なプロンプトを、構造化されたプロトコルへ圧縮すること。バッチ生成、テンプレートシステム、本番ワークフローへの組み込みが必要な場面では、個別事例を集めるだけよりも、この構造化のほうが大きな価値を持ちます。
+
+- 🧱 アトミック Schema：主体、光、素材、レイアウト、視覚ディテールを組み合わせ可能な部品へ分解
+- ⚙️ ワークフロー親和性：Agent、スクリプト、自動化システムで扱いやすい設計
+- 🧬 構造化制御：レイアウト、コピー、情報階層の制御性を高める構成
+
+## 📖 クイックリンク
+
+- [ケースギャラリー全体](docs/gallery.md)
+- [Gallery Part 1：ケース 1-165](docs/gallery-part-1.md)
+- [Gallery Part 2：ケース 166-484](docs/gallery-part-2.md)
+- [産業向けプロンプトテンプレートと落とし穴ガイド](docs/templates.md#section-templates)
+- [Agent Skill：GPT-Image2 Style Library](agents/skills/gpt-image-2-style-library/SKILL.md)
+- [MIT License](LICENSE)
+- [免責事項全文](docs/disclaimer.md#section-disclaimer)
+
+## 🗂️ カテゴリ概要
+
+まずケースアルバムで目指すビジュアル方向を見つけ、その後プロンプトテンプレートのカテゴリを開いて、再利用可能な構造へ落とし込みます。
+
+### 🖼️ ケースアルバム
+
+<table>
+  <tr>
+    <td width="33%" valign="top" align="center">
+      <p><strong>🧩 UI とインターフェース</strong><br><sub>73 cases</sub></p>
+      <a href="docs/gallery.md#cat-ui"><img src="data/images/category-covers/ui.jpg" alt="UI とインターフェース" width="220"></a><br>
+      <sub>アプリ、Web サイト、ダッシュボード、SNS スクリーンショット、プロダクト UI。</sub><br>
+      <a href="docs/gallery.md#cat-ui"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <p><strong>📊 チャートとインフォグラフィック</strong><br><sub>51 cases</sub></p>
+      <a href="docs/gallery.md#cat-infographic"><img src="data/images/category-covers/infographic.jpg" alt="チャートとインフォグラフィック" width="220"></a><br>
+      <sub>インフォグラフィック、ナレッジマップ、技術解説、構造化図解。</sub><br>
+      <a href="docs/gallery.md#cat-infographic"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <p><strong>📰 ポスターとタイポグラフィ</strong><br><sub>76 cases</sub></p>
+      <a href="docs/gallery.md#cat-poster"><img src="data/images/category-covers/poster.jpg" alt="ポスターとタイポグラフィ" width="220"></a><br>
+      <sub>イベントポスター、カバー、文字主体のビジュアル、強いレイアウト構成。</sub><br>
+      <a href="docs/gallery.md#cat-poster"><strong>ケースを見る</strong></a>
+    </td>
+  </tr>
+  <tr>
+    <td width="33%" valign="top" align="center">
+      <p><strong>🛍️ 商品と E コマース</strong><br><sub>37 cases</sub></p>
+      <a href="docs/gallery.md#cat-product"><img src="data/images/category-covers/product.jpg" alt="商品と E コマース" width="220"></a><br>
+      <sub>商品カット、詳細ページ、パッケージ、訴求ポイント、広告表現。</sub><br>
+      <a href="docs/gallery.md#cat-product"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <p><strong>🏷️ ブランドとロゴ</strong><br><sub>24 cases</sub></p>
+      <a href="docs/gallery.md#cat-brand"><img src="data/images/category-covers/brand.jpg" alt="ブランドとロゴ" width="220"></a><br>
+      <sub>ロゴ、アイデンティティシステム、ブランド接点、キャンペーンビジュアル。</sub><br>
+      <a href="docs/gallery.md#cat-brand"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <p><strong>🏛️ 建築と空間</strong><br><sub>11 cases</sub></p>
+      <a href="docs/gallery.md#cat-architecture"><img src="data/images/category-covers/architecture.jpg" alt="建築と空間" width="220"></a><br>
+      <sub>建築レンダリング、インテリア、都市地図、空間コンセプト。</sub><br>
+      <a href="docs/gallery.md#cat-architecture"><strong>ケースを見る</strong></a>
+    </td>
+  </tr>
+  <tr>
+    <td width="33%" valign="top" align="center">
+      <p><strong>📷 写真とリアリズム</strong><br><sub>64 cases</sub></p>
+      <a href="docs/gallery.md#cat-photo"><img src="data/images/category-covers/photo.jpg" alt="写真とリアリズム" width="220"></a><br>
+      <sub>ポートレート、スマートフォン写真、フィルム質感、商業写真。</sub><br>
+      <a href="docs/gallery.md#cat-photo"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <p><strong>🎨 イラストとアート</strong><br><sub>50 cases</sub></p>
+      <a href="docs/gallery.md#cat-illustration"><img src="data/images/category-covers/illustration.jpg" alt="イラストとアート" width="220"></a><br>
+      <sub>イラスト、アートスタイル、素材実験、装飾的な画面表現。</sub><br>
+      <a href="docs/gallery.md#cat-illustration"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <p><strong>🧍 キャラクターと人物</strong><br><sub>23 cases</sub></p>
+      <a href="docs/gallery.md#cat-character"><img src="data/images/category-covers/character.jpg" alt="キャラクターと人物" width="220"></a><br>
+      <sub>キャラクターデザイン、ポーズ資料、カード、3D トイ表現。</sub><br>
+      <a href="docs/gallery.md#cat-character"><strong>ケースを見る</strong></a>
+    </td>
+  </tr>
+  <tr>
+    <td width="33%" valign="top" align="center">
+      <p><strong>🎬 シーンとストーリーテリング</strong><br><sub>18 cases</sub></p>
+      <a href="docs/gallery.md#cat-scene"><img src="data/images/category-covers/scene.jpg" alt="シーンとストーリーテリング" width="220"></a><br>
+      <sub>絵コンテ、物語性のあるシーン、ライブ配信フレーム、世界観構築。</sub><br>
+      <a href="docs/gallery.md#cat-scene"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <p><strong>🏮 歴史と古典テーマ</strong><br><sub>16 cases</sub></p>
+      <a href="docs/gallery.md#cat-history"><img src="data/images/category-covers/history.jpg" alt="歴史と古典テーマ" width="220"></a><br>
+      <sub>古典絵巻、歴史人物、伝統題材、詩詞のビジュアル化。</sub><br>
+      <a href="docs/gallery.md#cat-history"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <p><strong>📚 ドキュメントと出版物</strong><br><sub>10 cases</sub></p>
+      <a href="docs/gallery.md#cat-document"><img src="data/images/category-covers/document.jpg" alt="ドキュメントと出版物" width="220"></a><br>
+      <sub>ホワイトペーパー、マニュアル、百科図版、出版レイアウト。</sub><br>
+      <a href="docs/gallery.md#cat-document"><strong>ケースを見る</strong></a>
+    </td>
+  </tr>
+  <tr>
+    <td width="33%" valign="top" align="center">
+      <p><strong>🧪 その他のユースケース</strong><br><sub>28 cases</sub></p>
+      <a href="docs/gallery.md#cat-other"><img src="data/images/category-covers/other.jpg" alt="その他のユースケース" width="220"></a><br>
+      <sub>クリエイティブ実験、特殊タスク、複合ワークフロー、実務ケース。</sub><br>
+      <a href="docs/gallery.md#cat-other"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <h4>🖼️ フルギャラリー</h4>
+      <a href="docs/gallery.md"><img src="data/images/category-covers/gallery.jpg" alt="フルギャラリー" width="220"></a><br>
+      <sub>全 484 件のケースをパートとカテゴリ別に閲覧できます。</sub><br>
+      <a href="docs/gallery.md"><strong>ギャラリーを開く</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <h4>⭐ 最新の事例</h4>
+      <a href="docs/gallery-part-2.md#case-484"><img src="data/images/case484.jpg" alt="最新の事例" width="220"></a><br>
+      <sub>リポジトリに新しく収録されたコミュニティ事例とワークフロー。</sub><br>
+      <a href="docs/gallery-part-2.md#case-484"><strong>最新を見る</strong></a>
+    </td>
+  </tr>
+</table>
+
+### 🧩 プロンプトテンプレートカテゴリ
+
+<details open>
+<summary><strong>Template Page 1 / 4：デザインと情報</strong></summary>
+
+| カテゴリ | テンプレート入口 | 中核機能 |
+|---|---|---|
+| 🧩 UI とインターフェース | [プロンプトを見る](docs/templates.md#tpl-ui) | コンポーネント、ページ階層、スクリーンショット質感 |
+| 📊 チャートとインフォグラフィック | [プロンプトを見る](docs/templates.md#tpl-infographic) | モジュール、矢印、データ構造、可読性 |
+| 📰 ポスターとタイポグラフィ | [プロンプトを見る](docs/templates.md#tpl-poster) | レイアウト、見出しシステム、人物、視覚的インパクト |
+
+</details>
+
+<details>
+<summary><strong>Template Page 2 / 4：商業と空間</strong></summary>
+
+| カテゴリ | テンプレート入口 | 中核機能 |
+|---|---|---|
+| 🛍️ 商品と E コマース | [プロンプトを見る](docs/templates.md#tpl-product) | 商品訴求、パッケージ、詳細ページ構成 |
+| 🏷️ ブランドとロゴ | [プロンプトを見る](docs/templates.md#tpl-brand) | ロゴ、アイデンティティ、ブランド接点システム |
+| 🏛️ 建築と空間 | [プロンプトを見る](docs/templates.md#tpl-architecture) | 透視、素材、屋内外のライティング |
+
+</details>
+
+<details>
+<summary><strong>Template Page 3 / 4：イメージングとキャラクター</strong></summary>
+
+| カテゴリ | テンプレート入口 | 中核機能 |
+|---|---|---|
+| 📷 写真とリアリズム | [プロンプトを見る](docs/templates.md#tpl-photo) | レンズ、ライティング、リアルな質感 |
+| 🎨 イラストとアート | [プロンプトを見る](docs/templates.md#tpl-illustration) | 筆致、素材、アートスタイル |
+| 🧍 キャラクターと人物 | [プロンプトを見る](docs/templates.md#tpl-character) | キャラクターデザイン、ポーズシート、一貫性 |
+
+</details>
+
+<details>
+<summary><strong>Template Page 4 / 4：ナラティブと拡張</strong></summary>
+
+| カテゴリ | テンプレート入口 | 中核機能 |
+|---|---|---|
+| 🎬 シーンとストーリーテリング | [プロンプトを見る](docs/templates.md#tpl-scene) | 絵コンテ、世界観構築、感情の流れ |
+| 🏮 歴史と古典テーマ | [プロンプトを見る](docs/templates.md#tpl-history) | 王朝、服飾、絵巻形式の語り |
+| 📚 ドキュメントと出版物 | [プロンプトを見る](docs/templates.md#tpl-document) | ページシステム、目次、レイアウト規則 |
+| 🧪 その他のユースケース | [プロンプトを見る](docs/templates.md#tpl-other) | 複合タスク、実験的ワークフロー、特殊出力 |
+
+</details>
+
+## 🤖 Agent Skill
+
+このリポジトリには、Web サイトと同じデータを使って GPT-Image2 のスタイル、テンプレート、カテゴリ、シーンタグを選定するための Agent Skill が含まれています。
+
+パッケージリンク：[npm](https://www.npmjs.com/package/gpt-image-2-style-library) / [GitHub Packages](https://github.com/freestylefly/awesome-gpt-image-2/pkgs/npm/gpt-image-2-style-library)
+
+<p align="center">
+  <img src="agents/skills/gpt-image-2-style-library/assets/city-life-system-map.png" alt="GPT-Image2 Style Library Skill で生成した都市生命システムマップ" width="760">
+</p>
+
+<p align="center"><sub>Style Library Skill を使った city-life-system-map リクエストの出力例。</sub></p>
+
+### Agent Skill のクイックインストール
+
+Claude Code、Codex、Cursor、および [`skills`](https://www.npmjs.com/package/skills) が対応するその他のツールには、次の方法を推奨します。
+
+```bash
+npx skills add freestylefly/awesome-gpt-image-2 --skill gpt-image-2-style-library --agent claude-code codex --global --yes --copy
+```
+
+対応するすべてのローカル Agent にインストールする場合：
+
+```bash
+npx skills add freestylefly/awesome-gpt-image-2 --global --all --copy
+```
+
+### Claude Code Plugin Marketplace
+
+Claude Code 内で次のコマンドを実行します。
+
+```text
+/plugin marketplace add freestylefly/awesome-gpt-image-2
+/plugin install gpt-image-2-style-library@awesome-gpt-image-2
+```
+
+### npm CLI
+
+npm を使う場合は、CLI をインストールしてからローカル Agent フォルダへ Skill を同期します。
+
+```bash
+npm install -g gpt-image-2-style-library
+gpt-image-2-style-library install all
+```
+
+グローバルインストールせずに実行することもできます。
+
+```bash
+npx gpt-image-2-style-library install all
+```
+
+GitHub Packages からインストールする場合：
+
+```bash
+npm login --scope=@freestylefly --registry=https://npm.pkg.github.com
+npm install -g @freestylefly/gpt-image-2-style-library --registry=https://npm.pkg.github.com
+gpt-image-2-style-library install all
+```
+
+`install all` は、Codex と Claude Code で一般的に使われるローカル Skill ディレクトリへ書き込みます。対象には `~/.codex/skills`、`~/.claude/skills`、`~/.agents/skills` が含まれます。インストール後は Agent セッションを再起動してください。
+
+次のようなリクエストで利用できます。
+
+```text
+gpt-image-2-style-library Skill を使って、Codex を紹介するインフォグラフィックのプロンプトを作成してください。
+```
+
+ローカルソース開発では次を実行します。
+
+```bash
+npm run generate:style-skill
+npm run install:skill
+```
+
+Skill のソースは [`agents/skills/gpt-image-2-style-library`](agents/skills/gpt-image-2-style-library/SKILL.md) にあります。生成されるリファレンスは [`data/style-library.json`](data/style-library.json) に基づいており、Web サイトと Agent ワークフローは同じスタイルライブラリを共有しています。
+
+## 🔐 Web サイト認証と生成
+
+ビジュアルサイトには、ログイン後にケース生成を試せる機能が含まれています。基盤には Supabase Auth、Supabase Postgres、GPT Image 2 API 向けの Vercel Function プロキシを使用しています。
+
+Vercel で必要な環境変数：
+
+```bash
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+SUPER_ADMIN_EMAILS=2689458656@qq.com,canghe0818@gmail.com
+CIYUAN_API_KEY=
+CIYUAN_BASE_URL=https://ciyuan.today
+APP_URL=https://gpt-image2.canghe.ai
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+VITE_GA_MEASUREMENT_ID=
+GA4_PROPERTY_ID=
+GOOGLE_ANALYTICS_CLIENT_ID=
+GOOGLE_ANALYTICS_CLIENT_SECRET=
+GOOGLE_ANALYTICS_REFRESH_TOKEN=
+```
+
+セットアップチェックリスト：
+
+- [`supabase/migrations/202605090001_user_credits.sql`](supabase/migrations/202605090001_user_credits.sql) を Supabase プロジェクトへ適用します。
+- [`supabase/migrations/20260509090000_membership_billing.sql`](supabase/migrations/20260509090000_membership_billing.sql) を適用し、メンバーシッププラン、クレジットパック、Stripe 注文レコード、クレジット調整 RPC を追加します。
+- [`supabase/migrations/20260512090000_google_account_center.sql`](supabase/migrations/20260512090000_google_account_center.sql) を適用し、アカウント利用サマリーとスーパー管理者向けの強制クレジット課金を追加します。
+- [`supabase/migrations/20260512143000_pricing_admin_metrics.sql`](supabase/migrations/20260512143000_pricing_admin_metrics.sql) を適用し、`$5 / 300 credits` のカタログを更新して管理ダッシュボード指標を追加します。
+- [`supabase/migrations/20260515090000_case_favorites.sql`](supabase/migrations/20260515090000_case_favorites.sql) を適用し、ユーザーごとのケースお気に入り機能を追加します。
+- Supabase Auth の Redirect URLs に `https://gpt-image2.canghe.ai` と、`http://127.0.0.1:5173` などのローカル開発 URL を追加します。
+- Supabase Dashboard に Google OAuth 認証情報を追加したうえで Google Provider を有効化します。
+- Google ログインのみに制限したい場合は、Supabase Auth settings で Email Provider を無効化します。
+- `SUPABASE_SERVICE_ROLE_KEY` は Vercel Environment Variables などのサーバーサイド環境にのみ保存してください。
+- Stripe Checkout の Webhook URL に `https://gpt-image2.canghe.ai/api/billing/webhook` を設定します。
+- Stripe Webhook で `checkout.session.completed`、`invoice.payment_succeeded`、`customer.subscription.updated`、`customer.subscription.deleted` を購読します。
+- `STRIPE_SECRET_KEY` と `STRIPE_WEBHOOK_SECRET` は、サーバーサイドの Vercel Environment Variables にのみ保存してください。
+- `gpt-image2.canghe.ai` 用の GA4 property を作成し、Measurement ID を `VITE_GA_MEASUREMENT_ID` に、数値の property ID を `GA4_PROPERTY_ID` に設定します。
+- Google OAuth Web Client を作成し、Authorized redirect URI に `http://localhost:8080/oauth2callback` を設定したうえで、`GOOGLE_ANALYTICS_CLIENT_ID` と `GOOGLE_ANALYTICS_CLIENT_SECRET` をローカルの `.env.local` に追加します。
+- `npm run ga4:oauth` を実行し、生成された URL を開いて `analytics.readonly` 権限を承認し、コールバック URL をターミナルへ貼り付けます。その後、返された `GOOGLE_ANALYTICS_REFRESH_TOKEN` を Vercel の Sensitive 環境変数として追加します。
+
+<a name="section-gallery"></a>
+
+## 🖼️ 注目ケース
+
+### Case 1：インフォグラフィック可視化
+
+[![Urban Metabolism Atlas](data/images/case1.jpg)](docs/gallery-part-1.md#case-1)
+
+モジュール構造、情報階層、バイリンガルラベルの設計を学ぶのに適した、エンジニアリングホワイトペーパー風のインフォグラフィック事例です。
+[ケース全体を見る](docs/gallery-part-1.md#case-1)
+
+### Case 2：SNS インターフェーススクリーンショット
+
+[![Ailln AI](data/images/case2.jpg)](docs/gallery-part-1.md#case-2)
+
+「プロダクト UI + SNS コンテンツスクリーンショット」を組み合わせた事例です。テキストブロック、UI フレーム、コンテンツカードの制御に向いています。
+[ケース全体を見る](docs/gallery-part-1.md#case-2)
+
+### Case 6：イラストレーションアート
+
+[![Japanese fantasy illustration](data/images/case6.jpg)](docs/gallery-part-1.md#case-6)
+
+雰囲気、色彩、大規模シーン構図を研究するための、日系ファンタジーイラストの例です。
+[ケース全体を見る](docs/gallery-part-1.md#case-6)
+
+### Case 17：インタラクションデザイン図
+
+[![Interaction design diagram](data/images/case17.jpg)](docs/gallery-part-1.md#case-17)
+
+プロダクト図解やポスター風の技術解説に使いやすい、典型的な「構造分解 + 説明レイアウト」の事例です。
+[ケース全体を見る](docs/gallery-part-1.md#case-17)
+
+### Case 166：十二人の黄金聖闘士カードセット
+
+[![Twelve Gold Saints card set](data/images/case166.jpg)](docs/gallery-part-2.md#case-166)
+
+バッチ生成とシリーズデザインを研究するための、複数カードを統一スタイルでまとめた事例です。
+[ケース全体を見る](docs/gallery-part-2.md#case-166)
+
+### Case 310：スナックブランド技術分解図
+
+[![Snack brand technical breakdown](data/images/case310.jpg)](docs/gallery-part-2.md#case-310)
+
+ブランドナラティブ、構造分解、商業的プレゼンテーションを強く組み合わせた事例です。「インフォグラフィック + ブランドビジュアル」の参考として有用です。
+[ケース全体を見る](docs/gallery-part-2.md#case-310)
+
+### 苍何(Canghe)による新規テスト
+
+<table>
+  <tr>
+    <td width="33%" valign="top" align="center">
+      <p><strong>Case 330：月明かりのライブ配信シーン</strong></p>
+      <a href="docs/gallery-part-2.md#case-330"><img src="data/images/category-covers/scene.jpg" alt="月明かりのライブ配信シーン" width="220"></a><br>
+      <sub>UI の雰囲気、弾幕コメント、リアルな人物表現を参照できる高精細ライブ配信スクリーンショット。</sub><br>
+      <a href="docs/gallery-part-2.md#case-330"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <p><strong>Case 334：RAG 技術解説図</strong></p>
+      <a href="docs/gallery-part-2.md#case-334"><img src="data/images/category-covers/infographic.jpg" alt="RAG 技術解説図" width="220"></a><br>
+      <sub>技術概念、フロー矢印、中国語キャプションモジュールの構成参考。</sub><br>
+      <a href="docs/gallery-part-2.md#case-334"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <p><strong>Case 338：赤壁古典絵巻</strong></p>
+      <a href="docs/gallery-part-2.md#case-338"><img src="data/images/category-covers/history.jpg" alt="赤壁古典絵巻" width="220"></a><br>
+      <sub>絵巻形式、古典的なナラティブ、全文レイアウトを統合した完成度の高い例。</sub><br>
+      <a href="docs/gallery-part-2.md#case-338"><strong>ケースを見る</strong></a>
+    </td>
+  </tr>
+  <tr>
+    <td width="33%" valign="top" align="center">
+      <p><strong>Case 331：手描き西安水彩マップ</strong></p>
+      <a href="docs/gallery-part-2.md#case-331"><img src="data/images/case331.png" alt="手描き西安水彩マップ" width="220"></a><br>
+      <sub>都市地図、手描きルート、ランドマークラベルの軽量な参考例。</sub><br>
+      <a href="docs/gallery-part-2.md#case-331"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <p><strong>Case 332：茶π 商品ポスター</strong></p>
+      <a href="docs/gallery-part-2.md#case-332"><img src="data/images/case332.png" alt="茶π 商品ポスター" width="220"></a><br>
+      <sub>中国語の訴求ポイントと清潔感のある商業ポスター表現を組み合わせた飲料商品ビジュアル。</sub><br>
+      <a href="docs/gallery-part-2.md#case-332"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="33%" valign="top" align="center">
+      <p><strong>Case 339：Apple 風ネイチャーサイエンスポスター</strong></p>
+      <a href="docs/gallery-part-2.md#case-339"><img src="data/images/case339.jpg" alt="Apple 風ネイチャーサイエンスポスター" width="220"></a><br>
+      <sub>ミニマルなスタジオ写真、自然物の主体、科学ポスター的な情報レイアウト。</sub><br>
+      <a href="docs/gallery-part-2.md#case-339"><strong>ケースを見る</strong></a>
+    </td>
+  </tr>
+</table>
+
+### コミュニティの最新事例
+
+ここでは最新の収集・インポート分のみを表示しています。過去のインポートはフルギャラリーに残されています。
+
+<table>
+  <tr>
+    <td width="25%" valign="top" align="center">
+      <p><strong>Case 477：Instagram ダイニングテーブルコンセプト</strong></p>
+      <a href="docs/gallery-part-2.md#case-477"><img src="data/images/case477.jpg" alt="Instagram ダイニングテーブルコンセプト" width="150"></a><br>
+      <sub>SNS 投稿レイアウトを、UI バンドと小物制約が明確な俯瞰のダイニングテーブルシーンへ変換した例。</sub><br>
+      <a href="docs/gallery-part-2.md#case-477"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="25%" valign="top" align="center">
+      <p><strong>Case 478：レイヤードブランド編集ポスター</strong></p>
+      <a href="docs/gallery-part-2.md#case-478"><img src="data/images/case478.jpg" alt="レイヤードブランド編集ポスター" width="150"></a><br>
+      <sub>幾何学的な遮蔽、抑えたカラーパレット、埋め込まれた商品ロジックを備えた 2x2 ブランドポスターシステム。</sub><br>
+      <a href="docs/gallery-part-2.md#case-478"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="25%" valign="top" align="center">
+      <p><strong>Case 479：雑誌風ペーパーコラージュリライト</strong></p>
+      <a href="docs/gallery-part-2.md#case-479"><img src="data/images/case479.jpg" alt="雑誌風ペーパーコラージュリライト" width="150"></a><br>
+      <sub>質感、手描きアクセント、余白、避けるべき要素まで指定された温かみのあるペーパーカットコラージュ。</sub><br>
+      <a href="docs/gallery-part-2.md#case-479"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="25%" valign="top" align="center">
+      <p><strong>Case 480：ファンスケッチブックのキャラクターページ</strong></p>
+      <a href="docs/gallery-part-2.md#case-480"><img src="data/images/case480.jpg" alt="ファンスケッチブックのキャラクターページ" width="150"></a><br>
+      <sub>キャラクターポーズ、ちびキャラ、クローズアップ、表情研究に向いた密度の高いスケッチブックページ。</sub><br>
+      <a href="docs/gallery-part-2.md#case-480"><strong>ケースを見る</strong></a>
+    </td>
+  </tr>
+  <tr>
+    <td width="25%" valign="top" align="center">
+      <p><strong>Case 481：韓国風春のスクラップブックポスター</strong></p>
+      <a href="docs/gallery-part-2.md#case-481"><img src="data/images/case481.jpg" alt="韓国風春のスクラップブックポスター" width="150"></a><br>
+      <sub>ステッカー、タイポグラフィ、パステルの庭園ムード、SNS カバー構図を組み合わせた春ファッションのスクラップブックポスター。</sub><br>
+      <a href="docs/gallery-part-2.md#case-481"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="25%" valign="top" align="center">
+      <p><strong>Case 482：シュルレアルな自己省察キャンペーン</strong></p>
+      <a href="docs/gallery-part-2.md#case-482"><img src="data/images/case482.jpg" alt="シュルレアルな自己省察キャンペーン" width="150"></a><br>
+      <sub>巨大な自己頭部プロップ、背景タイポグラフィ、アイデンティティ主導のムードを使ったミニマルなシュルレアルポートレート。</sub><br>
+      <a href="docs/gallery-part-2.md#case-482"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="25%" valign="top" align="center">
+      <p><strong>Case 483：都市の鳥とストリートポートレート</strong></p>
+      <a href="docs/gallery-part-2.md#case-483"><img src="data/images/case483.jpg" alt="都市の鳥とストリートポートレート" width="150"></a><br>
+      <sub>飛ぶ鳥、グラフィティのシルエット、自然光、エディトリアルな仕上げを含むシネマティックなストリートポートレート。</sub><br>
+      <a href="docs/gallery-part-2.md#case-483"><strong>ケースを見る</strong></a>
+    </td>
+    <td width="25%" valign="top" align="center">
+      <p><strong>Case 484：ネオングラフィティのモノクロポートレート</strong></p>
+      <a href="docs/gallery-part-2.md#case-484"><img src="data/images/case484.jpg" alt="ネオングラフィティのモノクロポートレート" width="150"></a><br>
+      <sub>ネオンの目、ペイントスプラッシュ、手描き要素、ストリートポスターのエネルギーを加えた高コントラストポートレート。</sub><br>
+      <a href="docs/gallery-part-2.md#case-484"><strong>ケースを見る</strong></a>
+    </td>
+  </tr>
+</table>
+
+#### 代表ケース 1：月明かりのライブ配信シーン
+
+[![月明かりのライブ配信シーン](data/images/case330.png)](docs/gallery-part-2.md#case-330)
+
+ライブ配信スクリーンショットのリアルな表現です。UI の雰囲気、中国語の弾幕、写実的な人物表現の組み合わせに注目できます。
+[ケース全体を見る](docs/gallery-part-2.md#case-330)
+
+#### 代表ケース 2：RAG 技術解説図
+
+[![RAG 技術解説図](data/images/case334.png)](docs/gallery-part-2.md#case-334)
+
+「技術概念 + インフォグラフィックレイアウト + 中国語キャプションモジュール」の構成方法を参照するのに適しています。
+[ケース全体を見る](docs/gallery-part-2.md#case-334)
+
+#### 代表ケース 3：『赤壁懐古』長巻図
+
+[![赤壁懐古長巻図](data/images/case338.png)](docs/gallery-part-2.md#case-338)
+
+長巻サイズ、古典的なナラティブ、全文の組版がよく統合された事例で、長文のビジュアル化の参考に適しています。
+[ケース全体を見る](docs/gallery-part-2.md#case-338)
+
+<a name="section-templates"></a>
+
+## 🧩 テンプレート入口
+
+完全なテンプレートライブラリは [`docs/templates.md`](docs/templates.md) にあります。カテゴリ別に素早く移動したい場合は、上の **プロンプトテンプレートカテゴリ** を利用してください。全文を確認したい場合は、[産業向けプロンプトテンプレートと落とし穴ガイド](docs/templates.md#section-templates) を開いてください。
+
+## 🚀 このリポジトリの使い方
+
+1. まず注目ケースから、模倣したい出力タイプを決めます。
+2. フルギャラリーを開き、近いケースを探します。最初に構造を写し、その後にスタイル語を調整します。
+3. 最後にテンプレートページへ戻り、一般テンプレートまたは JSON テンプレートへ自分の業務変数を入力します。
+
+<a name="section-disclaimer"></a>
+
+## 📄 注記と免責事項
+
+## 謝辞と出典
+
+本プロジェクトは、収集と研究の過程で [YouMind](https://youmind.com/) および [OpenNana](https://opennana.com/) の公開プロンプトライブラリを参照し、学習、要約、方法論研究の目的で利用しています。著作権は原作者または各プラットフォームに帰属します。権利侵害または不適切な利用がある場合はご連絡ください。速やかに修正または削除します。
+
+## 免責事項
+
+本プロジェクトは、公開アクセス可能なコミュニティプロンプトとサンプル画像を学習・研究目的で整理するものです。第三者のオリジナルコンテンツに対する所有権を主張するものではありません。
+
+このリポジトリ内のすべてのプロンプトケースと生成画像は、公開コミュニティ、特に [YouMind](https://youmind.com/) と [OpenNana](https://opennana.com/) から着想を得たものです。本プロジェクトの目的は、優れた事例を再利用可能な構造化プロトコルへ分解し、学習、要約、大規模モデル Agent による自動テストに活用することです。
+
+- 原作者プロフィール、元投稿リンク、ソースリポジトリリンクなど、可能な限り原典情報を保持するよう努めています。
+- 第三者コンテンツについては、ソースリポジトリの記載、`CC BY 4.0` などのライセンス、および関連プラットフォームの規約に従います。
+- 原作者または権利者として、特定の項目を表示すべきではないと考える場合は、該当項目のリンクを添えて Issue を作成してください。確認後、適切な場合は速やかに削除します。
+- 本リポジトリは、第三者コンテンツの商用利用可能性を保証しません。商用利用の前に、必ず元の権利者から許諾を取得してください。
+
+**このライブラリが役に立った場合は、ぜひリポジトリに Star をお願いします。**
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=freestylefly/awesome-gpt-image-2&type=Date)](https://star-history.com/#freestylefly/awesome-gpt-image-2&Date)
+
+## 📜 ライセンス
+
+本プロジェクトは [MIT License](LICENSE) のもとでオープンソース公開されています。ライセンス表示を保持する限り、自由に利用、変更、配布、二次開発できます。

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <strong>English</strong> | <a href="./README.zh-CN.md">简体中文</a>
+  <strong>English</strong> | <a href="./README.zh-CN.md">简体中文</a> | <a href="./README.ja.md">日本語</a>
 </p>
 
 > Updated irregularly with new workflows. Stars are welcome.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="./README.md">English</a> | <strong>简体中文</strong>
+  <a href="./README.md">English</a> | <strong>简体中文</strong> | <a href="./README.ja.md">日本語</a>
 </p>
 
 > 不定期更新最新的玩法，欢迎star。


### PR DESCRIPTION
## Summary
- 新增 `README.ja.md` 日本語翻訳(543 行)
- 在 `README.md` / `README.zh-CN.md` 顶部语言切换栏添加 `日本語` 链接

## Translation notes
- 用語は中国語版と英語版を相互参照し、原意を保ったまま日本人読者にとって自然な表現を選択
- 『聖闘士星矢』など日本オリジナルの固有名詞は正しい形に修正
- `苍何` には初出箇所でローマ字 `(Canghe)` を併記
- WeChat 返信キーワードには日本語訳を補足
- 環境変数・コマンド類・固有名詞(`Prompt-as-Code` 等)は原文ママを保持

## Test plan
- [x] Markdown レンダリング確認
- [x] 言語切替リンクの相互到達性(`README.md` ↔ `README.zh-CN.md` ↔ `README.ja.md`)
- [x] 中文版・英文版との構成・セクション順の一致
- [x] アンカーリンク(`docs/gallery.md#cat-*` など)が壊れていないこと