### PR TITLE
Fix broken star history charts

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -536,7 +536,7 @@ GOOGLE_ANALYTICS_REFRESH_TOKEN=
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=freestylefly/awesome-gpt-image-2&type=Date)](https://star-history.com/#freestylefly/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=freestylefly/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#freestylefly/awesome-gpt-image-2&Date)
 
 ## 📜 ライセンス
 

--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ All prompt cases and generated images in this repository were initially inspired
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=freestylefly/awesome-gpt-image-2&type=Date)](https://star-history.com/#freestylefly/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=freestylefly/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#freestylefly/awesome-gpt-image-2&Date)
 
 ## 📜 License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -539,7 +539,7 @@ GOOGLE_ANALYTICS_REFRESH_TOKEN=
 
 ## Star 趋势图
 
-[![Star History Chart](https://api.star-history.com/svg?repos=freestylefly/awesome-gpt-image-2&type=Date)](https://star-history.com/#freestylefly/awesome-gpt-image-2&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=freestylefly/awesome-gpt-image-2&type=Date)](https://star-history.dera.page/#freestylefly/awesome-gpt-image-2&Date)
 
 ## 📜 开源协议
 


### PR DESCRIPTION
The star history charts in the README files are currently broken. Update all localized README charts so they render correctly again while preserving the existing repository and date view.