### PR TITLE
fix(skill): 安装到 CLAUDE_CONFIG_DIR 而非不存在的 CLAUDE_HOME

### DIFF
--- a/agents/skills/gpt-image-2-style-library/bin/install.mjs
+++ b/agents/skills/gpt-image-2-style-library/bin/install.mjs
@@ -29,6 +29,12 @@ if (!allowedCommands.has(command)) {
   process.exit(1);
 }
 
+// Claude Code relocates ~/.claude via CLAUDE_CONFIG_DIR; CLAUDE_HOME is kept as a
+// fallback so anyone who set it for earlier versions of this installer still works.
+function claudeConfigDir() {
+  return process.env.CLAUDE_CONFIG_DIR || process.env.CLAUDE_HOME || join(homedir(), '.claude');
+}
+
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const entries = ['SKILL.md', 'agents', 'assets', 'references'];
 const targetDefinitions = {
@@ -38,7 +44,7 @@ const targetDefinitions = {
   },
   'claude-code': {
     label: 'Claude Code',
-    root: join(process.env.CLAUDE_HOME || join(homedir(), '.claude'), 'skills')
+    root: join(claudeConfigDir(), 'skills')
   },
   agents: {
     label: 'Shared agent skills',

--- a/scripts/install-style-skill.mjs
+++ b/scripts/install-style-skill.mjs
@@ -5,6 +5,13 @@ import { fileURLToPath } from 'node:url';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const skillName = 'gpt-image-2-style-library';
+
+// Claude Code relocates ~/.claude via CLAUDE_CONFIG_DIR; CLAUDE_HOME is kept as a
+// fallback so anyone who set it for earlier versions of this installer still works.
+function claudeConfigDir() {
+  return process.env.CLAUDE_CONFIG_DIR || process.env.CLAUDE_HOME || join(homedir(), '.claude');
+}
+
 const source = join(root, 'agents', 'skills', skillName);
 const targetDefinitions = {
   codex: {
@@ -13,7 +20,7 @@ const targetDefinitions = {
   },
   'claude-code': {
     label: 'Claude Code',
-    root: join(process.env.CLAUDE_HOME || join(homedir(), '.claude'), 'skills')
+    root: join(claudeConfigDir(), 'skills')
   },
   agents: {
     label: 'Shared agent skills',


### PR DESCRIPTION
## 问题 / The problem

两个安装脚本都用 `CLAUDE_HOME` 来定位 Claude Code 的 skills 目录：

```js
// scripts/install-style-skill.mjs 和
// agents/skills/gpt-image-2-style-library/bin/install.mjs
'claude-code': {
  label: 'Claude Code',
  root: join(process.env.CLAUDE_HOME || join(homedir(), '.claude'), 'skills')
},
```

但 Claude Code 并没有 `CLAUDE_HOME` 这个环境变量。用来把 `~/.claude` 迁移到别处的变量是 **`CLAUDE_CONFIG_DIR`** —— Claude Code 的设置、会话历史和插件都存在它指向的目录下，skills 自然也从那里读取（见 [Claude Code settings 文档](https://code.claude.com/docs/en/settings)：*"To keep the home-directory files somewhere else, set `CLAUDE_CONFIG_DIR`; Claude Code then stores your settings, session history, and plugins there instead."*）。

所以对于迁移过配置目录的用户，skill 会被装进一个 Claude Code 根本不会读的 `~/.claude/skills`，而且安装脚本还会打印成功信息 —— 用户只会看到技能"装好了"却始终不生效。

Codex 那一支用的 `CODEX_HOME` 是正确的（Codex CLI 确实用这个变量，默认 `~/.codex`），本 PR 不作改动。

## 改动 / What this PR does

`CLAUDE_CONFIG_DIR` 优先，`CLAUDE_HOME` 作为兼容回退保留，最后才是 `~/.claude`：

```js
// Claude Code relocates ~/.claude via CLAUDE_CONFIG_DIR; CLAUDE_HOME is kept as a
// fallback so anyone who set it for earlier versions of this installer still works.
function claudeConfigDir() {
  return process.env.CLAUDE_CONFIG_DIR || process.env.CLAUDE_HOME || join(homedir(), '.claude');
}
```

保留 `CLAUDE_HOME` 是为了不影响那些为了配合旧版安装脚本而专门设置过它的用户 —— 对他们来说行为完全不变。

两个文件都改了，因为 `bin/install.mjs` 是随 npm 包 `gpt-image-2-style-library` 发布出去的，`scripts/install-style-skill.mjs` 是仓库内 `npm run install:skill` 用的，两边逻辑保持一致。

## 验证 / Verification

```
# 1. CLAUDE_CONFIG_DIR 生效
$ CLAUDE_CONFIG_DIR=/tmp/t/relocated node scripts/install-style-skill.mjs claude-code
Installed gpt-image-2-style-library for Claude Code: /tmp/t/relocated/skills/gpt-image-2-style-library

# 2. 只设 CLAUDE_HOME 仍然可用（向后兼容）
$ CLAUDE_HOME=/tmp/t/legacy node scripts/install-style-skill.mjs claude-code
Installed gpt-image-2-style-library for Claude Code: /tmp/t/legacy/skills/gpt-image-2-style-library

# 3. 两个都设时 CLAUDE_CONFIG_DIR 优先（/tmp/t/loses 没有被创建）
$ CLAUDE_CONFIG_DIR=/tmp/t/wins CLAUDE_HOME=/tmp/t/loses node scripts/install-style-skill.mjs claude-code
Installed gpt-image-2-style-library for Claude Code: /tmp/t/wins/skills/gpt-image-2-style-library

# 4. npm 包里的安装器同样生效
$ CLAUDE_CONFIG_DIR=/tmp/t/pkg node agents/skills/gpt-image-2-style-library/bin/install.mjs claude-code
Installed gpt-image-2-style-library for Claude Code: /tmp/t/pkg/skills/gpt-image-2-style-library
```

`npm test` 28/28 通过。

---

**English summary:** Both installers read `CLAUDE_HOME` to locate the Claude Code skills directory, but Claude Code defines no such variable — the one that relocates `~/.claude` is `CLAUDE_CONFIG_DIR`. Anyone who has relocated their config directory got the skill installed into a `~/.claude/skills` that Claude Code never reads, while the installer reported success. This PR prefers `CLAUDE_CONFIG_DIR` and keeps `CLAUDE_HOME` as a backward-compatible fallback, in both the repo script and the installer published in the npm package. `CODEX_HOME` is correct and left untouched.
