### PR TITLE
fix(site): 画廊数据加载失败时不再永久卡在 loading

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -73,6 +73,8 @@ const watchaLogoUrl =
 const copy = {
   en: {
     loading: 'Loading GPT-Image2 cases...',
+    loadFailed: 'Could not load the gallery data.',
+    loadRetry: 'Retry',
     brand: 'GPT-Image2 Gallery',
     navCases: 'Cases',
     navSkill: 'Skill',
@@ -331,6 +333,8 @@ const copy = {
   },
   zh: {
     loading: '正在加载 GPT-Image2 案例...',
+    loadFailed: '画廊数据加载失败。',
+    loadRetry: '重试',
     brand: 'GPT-Image2 画廊',
     navCases: '案例',
     navSkill: '技能',
@@ -3582,6 +3586,8 @@ function App() {
   useGaPageViews();
   const [siteData, setSiteData] = useState(null);
   const [styleLibrary, setStyleLibrary] = useState(null);
+  const [siteDataFailed, setSiteDataFailed] = useState(false);
+  const [siteDataAttempt, setSiteDataAttempt] = useState(0);
   const [language, setLanguage] = useState(() => localStorage.getItem('language') || 'en');
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState('All');
@@ -3618,20 +3624,32 @@ function App() {
   useEffect(() => {
     let cancelled = false;
     cleanupExpiredGeneratedTests();
-    Promise.all([
-      fetch('/cases.json').then((response) => response.json()),
-      fetch('/style-library.json').then((response) => response.json())
-    ])
+
+    async function loadJson(url) {
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`${url} responded with ${response.status}`);
+      return response.json();
+    }
+
+    setSiteDataFailed(false);
+    Promise.all([loadJson('/cases.json'), loadJson('/style-library.json')])
       .then(([payload, library]) => {
         if (!cancelled) {
           setSiteData(payload);
           setStyleLibrary(library);
         }
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.warn('Failed to load site data', {
+          message: String(error?.message || 'unknown').slice(0, 240)
+        });
+        setSiteDataFailed(true);
       });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [siteDataAttempt]);
 
   useEffect(() => {
     let cancelled = false;
@@ -4040,9 +4058,25 @@ function App() {
   if (!siteData || !styleLibrary) {
     return (
       <main>
-        <div className="loadingScreen">
-          <WandSparkles size={28} />
-          <span>{t.loading}</span>
+        <div className={siteDataFailed ? 'loadingScreen loadingScreenFailed' : 'loadingScreen'}>
+          {siteDataFailed ? (
+            <>
+              <span>{t.loadFailed}</span>
+              <button
+                type="button"
+                className="iconTextButton"
+                onClick={() => setSiteDataAttempt((attempt) => attempt + 1)}
+              >
+                <RefreshCw size={16} />
+                {t.loadRetry}
+              </button>
+            </>
+          ) : (
+            <>
+              <WandSparkles size={28} />
+              <span>{t.loading}</span>
+            </>
+          )}
         </div>
       </main>
     );

--- a/src/styles.css
+++ b/src/styles.css
@@ -53,6 +53,14 @@ button {
   animation: cardDrift 2.2s ease-in-out infinite;
 }
 
+.loadingScreenFailed {
+  color: #ffc9c9;
+}
+
+.loadingScreenFailed svg {
+  animation: none;
+}
+
 .topbar {
   position: sticky;
   top: 0;


### PR DESCRIPTION
## 问题 / The problem

站点启动时加载画廊数据的这段 `Promise.all` 没有 `.catch()`，也没有检查 `response.ok`：

```js
Promise.all([
  fetch('/cases.json').then((response) => response.json()),
  fetch('/style-library.json').then((response) => response.json())
])
  .then(([payload, library]) => { ... });
```

只要任意一个请求失败，`siteData` 就永远是 `null`，页面会一直停在「正在加载 GPT-Image2 案例...」，控制台留下一个未处理的 promise rejection，访客除了手动刷新没有任何补救方式。

触发条件并不苛刻：只要返回的是一个 HTML 错误页（CDN 5xx、路径回退到 SPA fallback 等），`response.json()` 就会抛错，而且抛出的是 `Unexpected token '<', "<!doctype "... is not valid JSON` 这种和真实原因无关的报错。

复现（本地 dev server，让 `/cases.json` 回退到 SPA 的 HTML）：

```
[ERROR] Unexpected token '<', "<!doctype "... is not valid JSON
页面内容：Loading GPT-Image2 cases...   ← 永远停在这里
```

## 改动 / What this PR does

- 解析前先检查 `response.ok`，让 HTML 错误页报出真正的状态码，而不是 `Unexpected token '<'`
- 补上 `.catch()`，打印一条 warning 并进入失败状态
- 失败态显示提示文案和一个「重试」按钮，原地重新拉取，不需要整页刷新

中英文文案都加了（`loadFailed` / `loadRetry`）。按钮复用了已有的 `.iconTextButton` 样式和已经 import 的 `RefreshCw` 图标，CSS 只新增了失败态配色和停掉图标漂浮动画两条规则。

## 验证 / Verification

在 dev server 里把 `/cases.json` 改成返回 SPA fallback 的 HTML：

**改动前** —— 页面停在 loading，控制台 2 个 error（含未处理的 rejection）：

```yaml
- main:
  - generic: Loading GPT-Image2 cases...
```

**改动后** —— 0 error，rejection 被接住变成一条 warning，页面给出可操作的失败态：

```yaml
- main:
  - generic:
    - generic: Could not load the gallery data.
    - button "Retry"
```

**点击 Retry**（此时 `/cases.json` 已恢复）—— 无需刷新，画廊完整渲染，`535 matching cases`，模板区、skill 区都正常。

`npm run build` 通过。

---

**English summary:** The initial `Promise.all` that loads `/cases.json` and `/style-library.json` has no rejection handler and never checks `response.ok`, so any failure pins the app on the "Loading GPT-Image2 cases..." screen forever with an unhandled rejection in the console and no way for a visitor to recover. An HTML error page is enough to trigger it, and it surfaces as a misleading `Unexpected token '<'`. This PR checks `response.ok`, catches the rejection, and renders a failure state with a Retry button that re-runs the load in place. Verified end to end in the dev server: the stuck loading screen becomes an actionable message, and Retry renders the full gallery without a page reload.
