### PR TITLE
docs: add Astron skill integration guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -288,6 +288,20 @@ gpt-image-2-style-library install all
 
 `install all` は、Codex と Claude Code で一般的に使われるローカル Skill ディレクトリへ書き込みます。対象には `~/.codex/skills`、`~/.claude/skills`、`~/.agents/skills` が含まれます。インストール後は Agent セッションを再起動してください。
 
+### Astron SkillHub、Astron Agent、AstronClaw
+
+この Skill ディレクトリは SkillHub の OpenSkills 形式のパッケージ規約に準拠しています。`SKILL.md` がパッケージのルートにあり、参照資料とアセットもすべてパッケージ内にあります。そのまま [Astron SkillHub](https://github.com/iflytek/skillhub) レジストリへ公開できます。
+
+```bash
+npm install -g @astron-team/skillhub
+skillhub login --token sk_your_token_here --registry https://skillhub.example.com
+skillhub publish ./agents/skills/gpt-image-2-style-library --namespace my-team --visibility public --registry https://skillhub.example.com
+```
+
+公開後、Astron Agent の**リソース管理**から Skill をインポートし、標準 Agent またはワークフローに追加します。このパッケージには指示、参照資料、アセットのみが含まれるため、スクリプトサンドボックスを設定せずに `read_skill_*` から利用できます。公式の [SkillHub CLI ガイド](https://iflytek.github.io/skillhub/en/guide/cli)と [Astron Agent Skill FAQ](https://github.com/iflytek/astron-agent/blob/main/faq/features.md)も参照してください。
+
+AstronClaw では、[`agents/skills/gpt-image-2-style-library`](agents/skills/gpt-image-2-style-library/SKILL.md) の内容を ZIP にまとめ、`SKILL.md` がアーカイブのルートに来るようにして、**My Skills** からアップロードします。詳しくは [AstronClaw Skills ガイド](https://github.com/iflytek/astronclaw-tutorial/blob/main/docs/en/guide/astronclaw/skills.md)を参照してください。
+
 次のようなリクエストで利用できます。
 
 ```text

--- a/README.md
+++ b/README.md
@@ -291,6 +291,20 @@ gpt-image-2-style-library install all
 
 `install all` writes the skill to the common local folders used by Codex and Claude Code, including `~/.codex/skills`, `~/.claude/skills`, and `~/.agents/skills`. Restart the agent session after installing.
 
+### Astron SkillHub, Astron Agent, and AstronClaw
+
+The skill directory follows SkillHub's OpenSkills-style package contract: `SKILL.md` is at the package root and all references and assets are local. Publish it unchanged to an [Astron SkillHub](https://github.com/iflytek/skillhub) registry:
+
+```bash
+npm install -g @astron-team/skillhub
+skillhub login --token sk_your_token_here --registry https://skillhub.example.com
+skillhub publish ./agents/skills/gpt-image-2-style-library --namespace my-team --visibility public --registry https://skillhub.example.com
+```
+
+After publishing, import the skill from **Resource Management** in Astron Agent and attach it to a standard Agent or workflow. This package contains instructions, references, and assets only, so Astron Agent can use it through `read_skill_*` without a script sandbox. See the official [SkillHub CLI guide](https://iflytek.github.io/skillhub/en/guide/cli) and [Astron Agent skill FAQ](https://github.com/iflytek/astron-agent/blob/main/faq/features.md).
+
+For AstronClaw, zip the contents of [`agents/skills/gpt-image-2-style-library`](agents/skills/gpt-image-2-style-library/SKILL.md), keep `SKILL.md` at the archive root, and upload the ZIP from **My Skills**. See the [AstronClaw Skills guide](https://github.com/iflytek/astronclaw-tutorial/blob/main/docs/en/guide/astronclaw/skills.md).
+
 Use it with a request like:
 
 ```text

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -289,6 +289,20 @@ gpt-image-2-style-library install all
 
 `install all` 会写入 Codex 和 Claude Code 常用的本地技能目录，包括 `~/.codex/skills`、`~/.claude/skills`、`~/.agents/skills`。安装后重启 Agent 会话。
 
+### Astron SkillHub、Astron Agent 与 AstronClaw
+
+该技能目录符合 SkillHub 的 OpenSkills 风格包规范：`SKILL.md` 位于包根目录，引用资料和资源文件均在包内。可将其原样发布到 [Astron SkillHub](https://github.com/iflytek/skillhub) 实例：
+
+```bash
+npm install -g @astron-team/skillhub
+skillhub login --token sk_your_token_here --registry https://skillhub.example.com
+skillhub publish ./agents/skills/gpt-image-2-style-library --namespace my-team --visibility public --registry https://skillhub.example.com
+```
+
+发布后，在 Astron Agent 的**资源管理**中导入该技能，再将其添加到标准 Agent 或工作流。这个技能包只包含指令、引用资料和资源文件，因此 Astron Agent 可直接通过 `read_skill_*` 使用，无需配置脚本沙箱。详见官方 [SkillHub CLI 指南](https://iflytek.github.io/skillhub/guide/cli)与 [Astron Agent 技能 FAQ](https://github.com/iflytek/astron-agent/blob/main/faq/features.md)。
+
+使用 AstronClaw 时，可将 [`agents/skills/gpt-image-2-style-library`](agents/skills/gpt-image-2-style-library/SKILL.md) 目录内容打包为 ZIP，确保 `SKILL.md` 位于压缩包根目录，然后在**我的技能**中上传。详见 [AstronClaw 技能指南](https://github.com/iflytek/astronclaw-tutorial/blob/main/docs/guide/astronclaw/skills.md)。
+
 这样调用：
 
 ```text


### PR DESCRIPTION
## Summary

- document how to publish the existing `gpt-image-2-style-library` package to an Astron SkillHub registry
- explain how to import the published package into Astron Agent and why this reference-only skill does not need a script sandbox
- add the direct ZIP upload path for AstronClaw
- keep the English, Simplified Chinese, and Japanese README variants aligned

## Validation

- `git diff --check`
- verified `login`/`publish`, `--namespace`, `--visibility`, and `--registry` against the current official SkillHub CLI guide and source
- verified the added SkillHub, Astron Agent, and AstronClaw documentation links return HTTP 200

This is a documentation-only change; the skill package and generated style data are unchanged.

Closes #34
