### PR TITLE
feat(image): add optional Atlas Cloud backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 CIYUAN_API_KEY=
 CIYUAN_BASE_URL=https://ciyuan.today
 
+# Optional: switch the image backend to Atlas Cloud. Ciyuan remains the default.
+IMAGE_GENERATION_PROVIDER=ciyuan
+ATLASCLOUD_API_KEY=
+ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/api/v1
+ATLASCLOUD_IMAGE_MODEL=openai/gpt-image-2/text-to-image
+
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=

--- a/README.md
+++ b/README.md
@@ -319,6 +319,12 @@ SUPABASE_SERVICE_ROLE_KEY=
 SUPER_ADMIN_EMAILS=2689458656@qq.com,canghe0818@gmail.com
 CIYUAN_API_KEY=
 CIYUAN_BASE_URL=https://ciyuan.today
+
+# Optional Atlas Cloud backend (Ciyuan remains the default)
+IMAGE_GENERATION_PROVIDER=ciyuan
+ATLASCLOUD_API_KEY=
+ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/api/v1
+ATLASCLOUD_IMAGE_MODEL=openai/gpt-image-2/text-to-image
 APP_URL=https://gpt-image2.canghe.ai
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
@@ -328,6 +334,11 @@ GOOGLE_ANALYTICS_CLIENT_ID=
 GOOGLE_ANALYTICS_CLIENT_SECRET=
 GOOGLE_ANALYTICS_REFRESH_TOKEN=
 ```
+
+Set `IMAGE_GENERATION_PROVIDER=atlascloud` to use Atlas Cloud for generation.
+The Atlas backend submits each asynchronous generation task once, then polls the
+result endpoint with a bounded wait. `ATLASCLOUD_IMAGE_MODEL` may be changed only
+to a model whose current input schema accepts the configured request fields.
 
 Setup checklist:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -317,6 +317,12 @@ SUPABASE_SERVICE_ROLE_KEY=
 SUPER_ADMIN_EMAILS=2689458656@qq.com,canghe0818@gmail.com
 CIYUAN_API_KEY=
 CIYUAN_BASE_URL=https://ciyuan.today
+
+# 可选 Atlas Cloud 后端（默认仍为 Ciyuan）
+IMAGE_GENERATION_PROVIDER=ciyuan
+ATLASCLOUD_API_KEY=
+ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/api/v1
+ATLASCLOUD_IMAGE_MODEL=openai/gpt-image-2/text-to-image
 APP_URL=https://gpt-image2.canghe.ai
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
@@ -326,6 +332,10 @@ GOOGLE_ANALYTICS_CLIENT_ID=
 GOOGLE_ANALYTICS_CLIENT_SECRET=
 GOOGLE_ANALYTICS_REFRESH_TOKEN=
 ```
+
+设置 `IMAGE_GENERATION_PROVIDER=atlascloud` 可切换到 Atlas Cloud。Atlas 后端只
+提交一次异步生成任务，随后在有限时长内轮询结果接口。修改
+`ATLASCLOUD_IMAGE_MODEL` 前，请先确认目标模型的当前输入 schema 支持已配置字段。
 
 配置清单：
 

--- a/api/_lib/image-generation.js
+++ b/api/_lib/image-generation.js
@@ -1,0 +1,156 @@
+const DEFAULT_CIYUAN_BASE_URL = 'https://ciyuan.today';
+const DEFAULT_ATLASCLOUD_BASE_URL = 'https://api.atlascloud.ai/api/v1';
+const DEFAULT_ATLASCLOUD_MODEL = 'openai/gpt-image-2/text-to-image';
+const DEFAULT_POLL_TIMEOUT_MS = 10 * 60 * 1000;
+
+export function getImageGenerationProvider() {
+  return (process.env.IMAGE_GENERATION_PROVIDER || 'ciyuan').trim().toLowerCase();
+}
+
+export function isImageGenerationConfigured() {
+  const provider = getImageGenerationProvider();
+  if (provider === 'ciyuan') return Boolean(process.env.CIYUAN_API_KEY);
+  if (provider === 'atlascloud') return Boolean(process.env.ATLASCLOUD_API_KEY);
+  return false;
+}
+
+async function readJson(response, operation) {
+  const payload = await response.json().catch(() => ({}));
+  if (response.ok) return payload;
+
+  const message = payload?.error?.message
+    || payload?.message
+    || `${operation} failed with status ${response.status}`;
+  const error = new Error(message);
+  error.status = response.status;
+  error.code = payload?.error?.code || payload?.code;
+  error.type = payload?.error?.type || payload?.type;
+  throw error;
+}
+
+async function generateWithCiyuan(prompt, fetchImpl) {
+  const baseUrl = (process.env.CIYUAN_BASE_URL || DEFAULT_CIYUAN_BASE_URL).replace(/\/$/, '');
+  const response = await fetchImpl(`${baseUrl}/v1/images/generations`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.CIYUAN_API_KEY}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json'
+    },
+    body: JSON.stringify({
+      model: 'gpt-image-2',
+      prompt,
+      n: 1,
+      size: '1024x1024',
+      quality: 'low',
+      format: 'jpeg'
+    })
+  });
+  const payload = await readJson(response, 'Image generation');
+  const b64 = payload?.data?.[0]?.b64_json;
+  if (!b64) {
+    const error = new Error('Image generation response did not include image data');
+    error.status = response.status;
+    throw error;
+  }
+  return `data:image/jpeg;base64,${b64}`;
+}
+
+function unwrapPrediction(payload) {
+  return payload?.data && typeof payload.data === 'object' ? payload.data : payload;
+}
+
+function predictionError(prediction) {
+  const detail = prediction?.error || prediction?.message || prediction?.status || 'unknown error';
+  return typeof detail === 'string' ? detail : JSON.stringify(detail);
+}
+
+async function pollAtlasPrediction(id, fetchImpl, sleep, now, maxPollMs) {
+  const baseUrl = (process.env.ATLASCLOUD_BASE_URL || DEFAULT_ATLASCLOUD_BASE_URL).replace(/\/$/, '');
+  const startedAt = now();
+  let delayMs = 2000;
+
+  while (now() - startedAt < maxPollMs) {
+    await sleep(delayMs);
+    const response = await fetchImpl(`${baseUrl}/model/result/${encodeURIComponent(id)}`, {
+      headers: {
+        Authorization: `Bearer ${process.env.ATLASCLOUD_API_KEY}`,
+        'User-Agent': 'awesome-gpt-image-2/atlascloud'
+      }
+    });
+    const prediction = unwrapPrediction(await readJson(response, 'Atlas Cloud prediction'));
+    const status = String(prediction?.status || '').toLowerCase();
+    if (status === 'completed' || status === 'succeeded') return prediction;
+    if (['failed', 'canceled', 'cancelled'].includes(status)) {
+      throw new Error(`Atlas Cloud prediction ${status}: ${predictionError(prediction)}`);
+    }
+    delayMs = Math.min(Math.ceil(delayMs * 1.5), 15000);
+  }
+
+  throw new Error(`Atlas Cloud prediction timed out after ${Math.floor(maxPollMs / 1000)}s`);
+}
+
+async function outputToDataUrl(output, fetchImpl) {
+  if (output.startsWith('data:')) return output;
+  if (!/^https?:\/\//i.test(output)) return `data:image/jpeg;base64,${output}`;
+
+  const response = await fetchImpl(output);
+  if (!response.ok) {
+    const error = new Error(`Atlas Cloud image download failed with status ${response.status}`);
+    error.status = response.status;
+    throw error;
+  }
+  const contentType = response.headers.get('content-type') || 'image/jpeg';
+  const bytes = Buffer.from(await response.arrayBuffer());
+  return `data:${contentType};base64,${bytes.toString('base64')}`;
+}
+
+async function generateWithAtlasCloud(prompt, options) {
+  const { fetchImpl, sleep, now, maxPollMs } = options;
+  const baseUrl = (process.env.ATLASCLOUD_BASE_URL || DEFAULT_ATLASCLOUD_BASE_URL).replace(/\/$/, '');
+  const model = process.env.ATLASCLOUD_IMAGE_MODEL || DEFAULT_ATLASCLOUD_MODEL;
+
+  // This billable task submission is deliberately issued exactly once.
+  const response = await fetchImpl(`${baseUrl}/model/generateImage`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.ATLASCLOUD_API_KEY}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'awesome-gpt-image-2/atlascloud'
+    },
+    body: JSON.stringify({
+      model,
+      prompt,
+      size: '1024x1024',
+      quality: 'low',
+      output_format: 'jpeg',
+      enable_base64_output: true
+    })
+  });
+  let prediction = unwrapPrediction(await readJson(response, 'Atlas Cloud generation'));
+  const status = String(prediction?.status || '').toLowerCase();
+  if (status !== 'completed' && status !== 'succeeded') {
+    if (!prediction?.id) throw new Error('Atlas Cloud response did not include a prediction ID');
+    prediction = await pollAtlasPrediction(prediction.id, fetchImpl, sleep, now, maxPollMs);
+  }
+
+  const output = prediction?.outputs?.[0];
+  if (!output || typeof output !== 'string') {
+    throw new Error('Atlas Cloud prediction did not include image data');
+  }
+  return outputToDataUrl(output, fetchImpl);
+}
+
+export async function generateImage(prompt, options = {}) {
+  const provider = getImageGenerationProvider();
+  const runtime = {
+    fetchImpl: options.fetchImpl || globalThis.fetch,
+    sleep: options.sleep || ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs))),
+    now: options.now || Date.now,
+    maxPollMs: options.maxPollMs || DEFAULT_POLL_TIMEOUT_MS
+  };
+
+  if (provider === 'ciyuan') return generateWithCiyuan(prompt, runtime.fetchImpl);
+  if (provider === 'atlascloud') return generateWithAtlasCloud(prompt, runtime);
+  throw new Error(`Unsupported image generation provider: ${provider}`);
+}

--- a/api/_lib/image-generation.test.js
+++ b/api/_lib/image-generation.test.js
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  generateImage,
+  getImageGenerationProvider,
+  isImageGenerationConfigured
+} from './image-generation.js';
+
+function withEnv(t, values) {
+  const previous = new Map();
+  for (const [key, value] of Object.entries(values)) {
+    previous.set(key, process.env[key]);
+    if (value == null) delete process.env[key];
+    else process.env[key] = value;
+  }
+  t.after(() => {
+    for (const [key, value] of previous.entries()) {
+      if (value == null) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+}
+
+test('Ciyuan remains the default image generation provider', (t) => {
+  withEnv(t, {
+    IMAGE_GENERATION_PROVIDER: null,
+    CIYUAN_API_KEY: 'ciyuan-key',
+    ATLASCLOUD_API_KEY: null
+  });
+  assert.equal(getImageGenerationProvider(), 'ciyuan');
+  assert.equal(isImageGenerationConfigured(), true);
+});
+
+test('Ciyuan generation keeps the existing request and data URL contract', async (t) => {
+  withEnv(t, {
+    IMAGE_GENERATION_PROVIDER: null,
+    CIYUAN_API_KEY: 'ciyuan-key',
+    CIYUAN_BASE_URL: null
+  });
+  const calls = [];
+  const fetchImpl = async (input, init) => {
+    calls.push({ url: String(input), init });
+    return new Response(JSON.stringify({ data: [{ b64_json: 'AQID' }] }), { status: 200 });
+  };
+
+  const image = await generateImage('A cat', { fetchImpl });
+
+  assert.equal(image, 'data:image/jpeg;base64,AQID');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, 'https://ciyuan.today/v1/images/generations');
+  assert.deepEqual(JSON.parse(calls[0].init.body), {
+    model: 'gpt-image-2',
+    prompt: 'A cat',
+    n: 1,
+    size: '1024x1024',
+    quality: 'low',
+    format: 'jpeg'
+  });
+});
+
+test('Atlas Cloud submits once, polls the result endpoint, and returns a data URL', async (t) => {
+  withEnv(t, {
+    IMAGE_GENERATION_PROVIDER: 'atlascloud',
+    ATLASCLOUD_API_KEY: 'atlas-key',
+    ATLASCLOUD_IMAGE_MODEL: null,
+    ATLASCLOUD_BASE_URL: null
+  });
+  const calls = [];
+  const fetchImpl = async (input, init = {}) => {
+    const url = String(input);
+    calls.push({ url, method: init.method || 'GET', body: init.body || null });
+    if (url.endsWith('/model/generateImage')) {
+      return new Response(JSON.stringify({ id: 'prediction-1', status: 'created' }), { status: 200 });
+    }
+    if (url.endsWith('/model/result/prediction-1')) {
+      return new Response(JSON.stringify({
+        status: 'completed',
+        outputs: ['https://cdn.example.test/image.jpg']
+      }), { status: 200 });
+    }
+    return new Response(Uint8Array.from([255, 216, 255, 217]), {
+      status: 200,
+      headers: { 'Content-Type': 'image/jpeg' }
+    });
+  };
+
+  const image = await generateImage('A red paper airplane', {
+    fetchImpl,
+    sleep: async () => {},
+    now: () => 0,
+    maxPollMs: 1000
+  });
+
+  assert.equal(image, 'data:image/jpeg;base64,/9j/2Q==');
+  assert.equal(calls.filter((call) => call.method === 'POST').length, 1);
+  assert.deepEqual(JSON.parse(calls[0].body), {
+    model: 'openai/gpt-image-2/text-to-image',
+    prompt: 'A red paper airplane',
+    size: '1024x1024',
+    quality: 'low',
+    output_format: 'jpeg',
+    enable_base64_output: true
+  });
+  assert.deepEqual(calls.map((call) => call.url), [
+    'https://api.atlascloud.ai/api/v1/model/generateImage',
+    'https://api.atlascloud.ai/api/v1/model/result/prediction-1',
+    'https://cdn.example.test/image.jpg'
+  ]);
+});
+
+test('Atlas Cloud generation errors do not retry the billable POST', async (t) => {
+  withEnv(t, {
+    IMAGE_GENERATION_PROVIDER: 'atlascloud',
+    ATLASCLOUD_API_KEY: 'atlas-key'
+  });
+  let requests = 0;
+  const fetchImpl = async () => {
+    requests += 1;
+    return new Response(JSON.stringify({ message: 'upstream unavailable' }), { status: 503 });
+  };
+
+  await assert.rejects(
+    generateImage('A cat', { fetchImpl }),
+    /upstream unavailable/
+  );
+  assert.equal(requests, 1);
+});

--- a/api/generate-image.js
+++ b/api/generate-image.js
@@ -3,16 +3,19 @@ import {
   getProfileById,
   isSupabaseServerConfigured
 } from './_lib/supabase.js';
+import {
+  generateImage,
+  isImageGenerationConfigured
+} from './_lib/image-generation.js';
 
 const MAX_PROMPT_LENGTH = 6000;
-const DEFAULT_CIYUAN_BASE_URL = 'https://ciyuan.today';
 
 function json(res, status, payload) {
   res.status(status).json(payload);
 }
 
 function isServerConfigured() {
-  return Boolean(process.env.CIYUAN_API_KEY && isSupabaseServerConfigured());
+  return Boolean(isImageGenerationConfigured() && isSupabaseServerConfigured());
 }
 
 async function readBody(req) {
@@ -121,39 +124,6 @@ async function releaseReservation(client, reservationId, errorCode) {
       message: String(error?.message || 'unknown').slice(0, 240)
     });
   }
-}
-
-async function generateImage(prompt) {
-  const baseUrl = (process.env.CIYUAN_BASE_URL || DEFAULT_CIYUAN_BASE_URL).replace(/\/$/, '');
-  const response = await fetch(`${baseUrl}/v1/images/generations`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${process.env.CIYUAN_API_KEY}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json'
-    },
-    body: JSON.stringify({
-      model: 'gpt-image-2',
-      prompt,
-      n: 1,
-      size: '1024x1024',
-      quality: 'low',
-      format: 'jpeg'
-    })
-  });
-  const payload = await response.json().catch(() => ({}));
-  const b64 = payload?.data?.[0]?.b64_json;
-
-  if (!response.ok || !b64) {
-    const message = payload?.error?.message || payload?.message || `Image generation failed with status ${response.status}`;
-    const error = new Error(message);
-    error.status = response.status;
-    error.code = payload?.error?.code || payload?.code;
-    error.type = payload?.error?.type || payload?.type;
-    throw error;
-  }
-
-  return `data:image/jpeg;base64,${b64}`;
 }
 
 export default async function handler(req, res) {


### PR DESCRIPTION
## Summary

- extract image generation behind a small backend module while keeping Ciyuan as the default
- add an opt-in Atlas Cloud GPT Image 2 backend selected through server environment variables
- submit Atlas generation tasks once, poll the documented result endpoint with a bounded wait, and preserve the existing data URL response contract
- document configuration and test both the existing Ciyuan path and Atlas request behavior

## Validation

- `npm test` (32 passed)
- `npm run build`
- `node --check api/_lib/image-generation.js`
- live 1024x1024 Atlas Cloud smoke with `openai/gpt-image-2/text-to-image` (one generation submission)